### PR TITLE
[Feat] rabbitmq 설정 추가 및 보상 트랜잭션 기능 구현

### DIFF
--- a/common/src/main/java/com/takeit/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/takeit/common/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "해당 작업에 대한 권한이 없습니다."),
+    JSON_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "JsonProcessingException"),
 
     // Payment
     WRONG_PAYMENT(HttpStatus.BAD_REQUEST, "결제 정보가 잘못되었습니다."),
@@ -37,6 +38,7 @@ public enum ErrorCode {
     // order
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 주문 정보입니다."),
     ORDER_CANNOT_BE_MODIFIED(HttpStatus.BAD_REQUEST, "현재 상태의 주문은 수정할 수 없습니다."),
+    ORDER_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소 처리된 주문입니다."),
 
     // category
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리가 없습니다."),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,17 @@ networks:
     driver: bridge
 
 services:
+  rabbitMQ:
+    image: rabbitmq:management
+    container_name: rabbitMQ
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - ./rabbitMQ-data:/data
+    networks:
+      - takeit-network
+
   postgres:
     image: postgres:latest
     container_name: postgres

--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -15,4 +15,8 @@ dependencies {
 
 	// PostgreSQL
 	runtimeOnly "org.postgresql:postgresql:${postgresqlVersion}"
+
+	// rabbitMQ
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	testImplementation 'org.springframework.amqp:spring-rabbit-test'
 }

--- a/order-service/src/main/java/com/takeit/order/application/dto/product/CancelProduct.java
+++ b/order-service/src/main/java/com/takeit/order/application/dto/product/CancelProduct.java
@@ -1,0 +1,10 @@
+package com.takeit.order.application.dto.product;
+
+public record CancelProduct(
+        Long productId,
+        Long quantity
+) {
+    public static CancelProduct create(Long productId, Long quantity) {
+        return new CancelProduct(productId, quantity);
+    }
+}

--- a/order-service/src/main/java/com/takeit/order/application/service/OrderService.java
+++ b/order-service/src/main/java/com/takeit/order/application/service/OrderService.java
@@ -5,8 +5,13 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.takeit.order.application.dto.OrderDto;
 
+import com.takeit.order.application.dto.product.CancelProduct;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -41,6 +46,10 @@ public class OrderService {
 	private final OrderRepository orderRepository;
 	private final ProductClient productClient;
 	private final CouponClient couponClient;
+
+	private final RabbitTemplate rabbitTemplate;
+	@Value("${message.queues.product.cancel}")
+	private String productQueue;
 
 	@Transactional
 	public OrderResponse createOrder(OrderCreateDto request, Long userId) {
@@ -196,5 +205,23 @@ public class OrderService {
 		if (products.isEmpty())
 			throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
 		return products.get(0);
+	}
+
+	@Transactional
+	public void cancelOrder(Long orderId) {
+		Order order = orderRepository.findById(orderId).orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+		checkCanCanceled(order.getStatus());
+		order.cancel();
+		try {
+			ObjectMapper objectMapper = new ObjectMapper();
+			String message = objectMapper.writeValueAsString(CancelProduct.create(order.getProductId(), order.getQuantity()));
+			rabbitTemplate.convertAndSend(productQueue, message);
+		} catch (JsonProcessingException e) {
+            throw new CustomException(ErrorCode.JSON_PROCESSING_ERROR);
+        }
+    }
+
+	private void checkCanCanceled(OrderStatus status) {
+		if(status == OrderStatus.CANCELLED) throw new CustomException(ErrorCode.ORDER_ALREADY_CANCELED);
 	}
 }

--- a/order-service/src/main/java/com/takeit/order/domain/repository/OrderRepository.java
+++ b/order-service/src/main/java/com/takeit/order/domain/repository/OrderRepository.java
@@ -16,4 +16,6 @@ public interface OrderRepository {
 	Optional<Order> findByUuid(UUID uuid);
 	Page<Order> findByCustomerId(Long customerId, Pageable pageable);
 	Page<Order> findByCustomerIdAndStatus(Long customerId, OrderStatus orderStatus, Pageable pageable);
+
+    Optional<Order> findById(Long orderId);
 }

--- a/order-service/src/main/java/com/takeit/order/infrastructure/config/RabbitMQConfig.java
+++ b/order-service/src/main/java/com/takeit/order/infrastructure/config/RabbitMQConfig.java
@@ -1,0 +1,36 @@
+package com.takeit.order.infrastructure.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class RabbitMQConfig {
+
+    @Value("${message.exchange}")
+    private String exchange;
+
+    @Value("${message.queues.product.cancel}")
+    private String queueProduct;
+
+    @Value("${message.queues.order.cancel}")
+    private String queueOrder;
+
+    @Bean
+    public TopicExchange orderExchange() { return new TopicExchange(exchange); }
+
+    @Bean
+    public Queue productQueue() { return new Queue(queueProduct); }
+
+    @Bean
+    public Queue orderQueue() { return new Queue(queueOrder); }
+
+    @Bean
+    public Binding productBinding() { return BindingBuilder.bind(productQueue()).to(orderExchange()).with(queueProduct); }
+}

--- a/order-service/src/main/java/com/takeit/order/presentation/controller/OrderMessageListener.java
+++ b/order-service/src/main/java/com/takeit/order/presentation/controller/OrderMessageListener.java
@@ -1,0 +1,20 @@
+package com.takeit.order.presentation.controller;
+
+import com.takeit.order.application.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderMessageListener {
+    private final OrderService orderService;
+
+    @RabbitListener(queues = "${message.queues.order.cancel}")
+    public void receiveMessage(Long orderId) {
+        log.info("Received message");
+        orderService.cancelOrder(orderId);
+    }
+}

--- a/order-service/src/main/resources/application-dev.yml
+++ b/order-service/src/main/resources/application-dev.yml
@@ -10,6 +10,11 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
 
 server:
   port: 19098
@@ -35,3 +40,11 @@ management:
       show-details: always
     prometheus:
       enabled: true
+
+message:
+  exchange: "takeit"
+  queues:
+    order:
+      cancel: "takeit.order.cancel"
+    product:
+      cancel: "takeit.product.cancel"

--- a/order-service/src/main/resources/application-local.yml
+++ b/order-service/src/main/resources/application-local.yml
@@ -10,6 +10,11 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
 
 server:
   port: 19098
@@ -35,3 +40,11 @@ management:
       show-details: always
     prometheus:
       enabled: true
+
+message:
+  exchange: "takeit"
+  queues:
+    order:
+      cancel: "takeit.order.cancel"
+    product:
+      cancel: "takeit.product.cancel"

--- a/order-service/src/main/resources/application-prod.yml
+++ b/order-service/src/main/resources/application-prod.yml
@@ -15,6 +15,11 @@ spring:
         format_sql: true
         default_batch_fetch_size: 100
     open-in-view: false
+  rabbitmq:
+    host: ${RABBITMQ_HOST}
+    port: ${RABBITMQ_PORT}
+    username: ${RABBITMQ_USERNAME}
+    password: ${RABBITMQ_PASSWORD}
 
 server:
   port: ${ORDER_SERVICE_PORT}
@@ -36,3 +41,11 @@ management:
       show-details: when_authorized
     prometheus:
       enabled: true
+
+message:
+  exchange: ${RABBITMQ_EXCHANGE}
+  queues:
+    order:
+      cancel: ${MESSAGE_QUEUE_ORDER_CANCEL}
+    product:
+      cancel: ${MESSAGE_QUEUE_PRODUCT_CANCEL}

--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -21,4 +21,8 @@ dependencies {
 
 	// PostgreSQL
 	runtimeOnly "org.postgresql:postgresql:${postgresqlVersion}"
+
+	// rabbitMQ
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	testImplementation 'org.springframework.amqp:spring-rabbit-test'
 }

--- a/payment-service/src/main/java/com/takeit/payment/application/service/PaymentService.java
+++ b/payment-service/src/main/java/com/takeit/payment/application/service/PaymentService.java
@@ -7,6 +7,8 @@ import com.takeit.payment.application.dto.payment.VerifyTossPaymentDto;
 import com.takeit.payment.domain.entity.Payment;
 import com.takeit.payment.domain.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +17,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PaymentService {
     private final PaymentRepository paymentRepository;
+    private final RabbitTemplate rabbitTemplate;
+
+    @Value("${message.queue.order.cancel}")
+    private String queueOrder;
 
     @Transactional
     public void verifyTossPayment(VerifyTossPaymentDto request, String username) {
@@ -24,13 +30,14 @@ public class PaymentService {
         Long orderId = 1L;
 
         // TODO: pg사에 결제 확인(실제로는 try catch를 통해 진행해야함)
-        boolean isPaymentSuccess = true;
+        boolean isPaymentSuccess = false;
         String receipt = "영수증";
 
         if(isPaymentSuccess) {
             paymentRepository.save(Payment.create(orderId, userId, request.amount(), receipt));
         } else {
-            throw new CustomException(ErrorCode.WRONG_PAYMENT);
+            rabbitTemplate.convertAndSend(queueOrder, orderId);
+//            throw new CustomException(ErrorCode.WRONG_PAYMENT);
         }
 
     }
@@ -47,6 +54,7 @@ public class PaymentService {
 
         if(isPaymentCanceled) {
             payment.cancel();
+            rabbitTemplate.convertAndSend(queueOrder, request.orderId());
         } else {
             throw new CustomException(ErrorCode.PAYMENT_CANCEL_FAIL);
         }

--- a/payment-service/src/main/java/com/takeit/payment/infrastructure/config/RabbitMQConfig.java
+++ b/payment-service/src/main/java/com/takeit/payment/infrastructure/config/RabbitMQConfig.java
@@ -1,0 +1,31 @@
+package com.takeit.payment.infrastructure.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class RabbitMQConfig {
+
+    @Value("${message.exchange}")
+    private String exchange;
+
+    @Value("${message.queue.order.cancel}")
+    private String queueOrder;
+
+    @Bean
+    public TopicExchange paymentExchange() { return new TopicExchange(exchange); }
+
+    @Bean
+    public Queue orderQueue() { return new Queue(queueOrder); }
+
+    @Bean
+    public Binding orderBinding() { return BindingBuilder.bind(orderQueue()).to(paymentExchange()).with(queueOrder); }
+
+}

--- a/payment-service/src/main/resources/application-dev.yml
+++ b/payment-service/src/main/resources/application-dev.yml
@@ -12,6 +12,12 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
+
 server:
   port: 19095
 
@@ -36,3 +42,9 @@ management:
       show-details: always
     prometheus:
       enabled: true
+
+message:
+  exchange: "takeit"
+  queue:
+    order:
+      cancel: "takeit.order.cancel"

--- a/payment-service/src/main/resources/application-local.yml
+++ b/payment-service/src/main/resources/application-local.yml
@@ -11,6 +11,11 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
 
 server:
   port: 19095
@@ -36,3 +41,8 @@ management:
       show-details: always
     prometheus:
       enabled: true
+message:
+  exchange: "takeit"
+  queue:
+    order:
+      cancel: "takeit.order.cancel"

--- a/payment-service/src/main/resources/application-prod.yml
+++ b/payment-service/src/main/resources/application-prod.yml
@@ -16,6 +16,12 @@ spring:
         default_batch_fetch_size: 100
     open-in-view: false
 
+  rabbitmq:
+    host: ${RABBITMQ_HOST}
+    port: ${RABBITMQ_PORT}
+    username: ${RABBITMQ_USERNAME}
+    password: ${RABBITMQ_PASSWORD}
+
 server:
   port: ${PAYMENT_SERVICE_PORT}
 
@@ -36,3 +42,9 @@ management:
       show-details: when_authorized
     prometheus:
       enabled: true
+
+message:
+  exchange: ${RABBITMQ_EXCHANGE}
+  queue:
+    order:
+      cancel: ${MESSAGE_QUEUE_ORDER_CANCEL}

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -23,4 +23,11 @@ dependencies {
 
 	// PostgreSQL
 	runtimeOnly "org.postgresql:postgresql:${postgresqlVersion}"
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// rabbitMQ
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	testImplementation 'org.springframework.amqp:spring-rabbit-test'
 }

--- a/product-service/src/main/java/com/takeit/product/application/dto/product/CancelProduct.java
+++ b/product-service/src/main/java/com/takeit/product/application/dto/product/CancelProduct.java
@@ -1,0 +1,7 @@
+package com.takeit.product.application.dto.product;
+
+public record CancelProduct(
+        Long productId,
+        Long quantity
+)  {}
+

--- a/product-service/src/main/java/com/takeit/product/application/service/ProductRedisService.java
+++ b/product-service/src/main/java/com/takeit/product/application/service/ProductRedisService.java
@@ -1,0 +1,23 @@
+package com.takeit.product.application.service;
+
+import com.takeit.product.application.dto.product.CancelProduct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductRedisService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void cancelProduct(CancelProduct request) {
+        String key = "product:" + request.productId();
+        log.info("[cancel product] id : {}, amount : {}", request.productId(), request.quantity());
+        redisTemplate.opsForValue().increment(key, request.quantity());
+    }
+}

--- a/product-service/src/main/java/com/takeit/product/infrastructure/config/RabbitMQConfig.java
+++ b/product-service/src/main/java/com/takeit/product/infrastructure/config/RabbitMQConfig.java
@@ -1,0 +1,32 @@
+package com.takeit.product.infrastructure.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class RabbitMQConfig {
+
+    @Value("${message.queue.product.cancel}")
+    private String queueProduct;
+
+    @Bean
+    public Queue productQueue() { return new Queue(queueProduct); }
+
+//    @Bean
+//    public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(ConnectionFactory connectionFactory) {
+//        SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+//        factory.setConnectionFactory(connectionFactory);
+//        factory.setAdviceChain(RetryInterceptorBuilder.stateless()
+//                .maxAttempts(3) // 최대 재시도 횟수 설정
+//                .recoverer(new RejectAndDontRequeueRecoverer()) // 실패 시 메시지 처리 중단
+//                .build());
+//        return factory;
+//    }
+}

--- a/product-service/src/main/java/com/takeit/product/infrastructure/config/RedisConfig.java
+++ b/product-service/src/main/java/com/takeit/product/infrastructure/config/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.takeit.product.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        // Key Serializer 설정
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+
+        // Value Serializer 설정 (JSON 직렬화)
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/product-service/src/main/java/com/takeit/product/presentation/controller/ProductMessageListener.java
+++ b/product-service/src/main/java/com/takeit/product/presentation/controller/ProductMessageListener.java
@@ -1,0 +1,30 @@
+package com.takeit.product.presentation.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.takeit.product.application.dto.product.CancelProduct;
+import com.takeit.product.application.service.ProductRedisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductMessageListener {
+    private final ProductRedisService productRedisService;
+
+    @RabbitListener(queues = "${message.queue.product.cancel}")
+    public void receiveMessage(String message) {
+        log.info("Received message");
+
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            CancelProduct cancelProduct = objectMapper.readValue(message, CancelProduct.class);
+            productRedisService.cancelProduct(cancelProduct);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/product-service/src/main/resources/application-dev.yml
+++ b/product-service/src/main/resources/application-dev.yml
@@ -17,6 +17,18 @@ spring:
       hibernate:
         format_sql: true
 
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: systempass
+
 server:
   port: 19094
 
@@ -54,3 +66,8 @@ management:
       show-details: always
     prometheus:
       enabled: true
+
+message:
+  queue:
+    product:
+      cancel: "takeit.product.cancel"

--- a/product-service/src/main/resources/application-local.yml
+++ b/product-service/src/main/resources/application-local.yml
@@ -17,6 +17,18 @@ spring:
       hibernate:
         format_sql: true
 
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: systempass
+
 server:
   port: 19094
 
@@ -54,3 +66,8 @@ management:
       show-details: always
     prometheus:
       enabled: true
+
+message:
+  queue:
+    product:
+     cancel: "takeit.product.cancel"

--- a/product-service/src/main/resources/application-prod.yml
+++ b/product-service/src/main/resources/application-prod.yml
@@ -16,6 +16,18 @@ spring:
         default_batch_fetch_size: 100
     open-in-view: false
 
+  rabbitmq:
+    host: ${RABBITMQ_HOST}
+    port: ${RABBITMQ_PORT}
+    username: ${RABBITMQ_USERNAME}
+    password: ${RABBITMQ_PASSWORD}
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+
 server:
   port: ${PRODUCT_SERVICE_PORT}
 
@@ -49,3 +61,8 @@ management:
       show-details: when_authorized
     prometheus:
       enabled: true
+
+message:
+  queue:
+    product:
+      cancel: ${MESSAGE_QUEUE_PRODUCT_CANCEL}

--- a/review-service/src/main/resources/application-dev.yml
+++ b/review-service/src/main/resources/application-dev.yml
@@ -14,6 +14,11 @@ spring:
           highlight_sql: true
           default_batch_fetch_size: 10
       open-in-view: false
+    data:
+      redis:
+        host: localhost
+        port: 6379
+        password: systempass
 
 server:
   port: 19096


### PR DESCRIPTION
## **🔗 Related Issues**
> #108 


## **📋 Description**
- payment -> order -> product 순으로 보상 트랜잭션 메세지가 전송됩니다.
- 우선 redis set 으로  key : product:{productId}, value : 수량 이라고 생각하고 만들었고 다르게 수량을 저장시킨다면 수정해야합니다.
- payment 실패 혹은 취소 요청을 받으면 order에 takeit.order.cancel queue를 통해 message 전송합니다.
- order에서 messageListener를 통해 메세지를 받으면 주문 취소를 하고 product에 takeit.product.cancel queue를 통해 message를 전송합니다.
- product에서 messageListener를 통해 메세지를 받으면 productRedisService에서 redis에 있는 product의 수량을 증가시켜줍니다.

- prod에 추가해야 할 환경변수
  - ${RABBITMQ_HOST}
  - ${RABBITMQ_PORT}
  - ${RABBITMQ_USERNAME}
  - ${RABBITMQ_PASSWORD}
  - ${RABBITMQ_EXCHANGE}
  - ${MESSAGE_QUEUE_ORDER_CANCEL}
  - ${MESSAGE_QUEUE_PRODUCT_CANCEL}
- 동작은 rabbitmq UI를 통해 확인했고, db 데이터 수정도 되는 것을 확인했습니다.
- 현재 보낸  message가 정상 동작을 하는 경우에 대한 코드만 작성되었고, message error 처리에 대한 rollback은 pr 이후에 추가해보도록 하겠습니다.

## **👀 Review Points**
- 처음 시도한 mq라 고쳐야할 부분 있다면 코멘트 많이 달아주세요.
- 수량 증가 시키는 부분에서 분산락을 적용시켜야할까요?
