### PR TITLE
[Feat] 결제 성공 시 주문 정보 저장 기능 구현

### DIFF
--- a/order-service/src/main/java/com/takeit/order/application/dto/order/OrderCompleteDto.java
+++ b/order-service/src/main/java/com/takeit/order/application/dto/order/OrderCompleteDto.java
@@ -1,0 +1,9 @@
+package com.takeit.order.application.dto.order;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+public record OrderCompleteDto(
+	UUID orderId
+) implements Serializable {
+}

--- a/order-service/src/main/java/com/takeit/order/domain/entity/Order.java
+++ b/order-service/src/main/java/com/takeit/order/domain/entity/Order.java
@@ -51,15 +51,15 @@ public class Order extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private OrderStatus status;
 
-	public static Order create(Long customerId, Long productId, Long userCouponId, Long quantity, Long amount) {
+	public static Order create(UUID uuid, Long customerId, Long productId, Long userCouponId, Long quantity, Long amount) {
 		return Order.builder()
-			.uuid(UUID.randomUUID())
+			.uuid(uuid)
 			.customerId(customerId)
 			.productId(productId)
 			.userCouponId(userCouponId)
 			.quantity(quantity)
 			.amount(amount)
-			.status(OrderStatus.PENDING)
+			.status(OrderStatus.COMPLETED)
 			.build();
 	}
 

--- a/order-service/src/main/java/com/takeit/order/domain/enums/OrderStatus.java
+++ b/order-service/src/main/java/com/takeit/order/domain/enums/OrderStatus.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum OrderStatus {
-	PENDING,
 	COMPLETED,
 	DELIVERED,
 	CANCELLED;
@@ -14,7 +13,6 @@ public enum OrderStatus {
 	public static OrderStatus of(String request){
 		if(request==null) return null;
 		return switch (request){
-			case "PENDING" -> PENDING;
 			case "COMPLETED" -> COMPLETED;
 			case "DELIVERED" -> DELIVERED;
 			case "CANCELLED" -> CANCELLED;

--- a/order-service/src/main/java/com/takeit/order/infrastructure/config/RabbitMQConfig.java
+++ b/order-service/src/main/java/com/takeit/order/infrastructure/config/RabbitMQConfig.java
@@ -24,6 +24,9 @@ public class RabbitMQConfig {
     @Value("${message.queues.order.cancel}")
     private String queueOrder;
 
+    @Value("${message.queues.order.complete}")
+    private String queueOrderComplete;
+
     @Bean
     public TopicExchange orderExchange() { return new TopicExchange(exchange); }
 
@@ -34,7 +37,18 @@ public class RabbitMQConfig {
     public Queue orderQueue() { return new Queue(queueOrder); }
 
     @Bean
+    public Queue orderCompleteQueue() { return new Queue(queueOrderComplete); }
+
+    @Bean
     public Binding productBinding() { return BindingBuilder.bind(productQueue()).to(orderExchange()).with(queueProduct); }
+
+    @Bean
+    public Binding orderCompleteBinding() {
+        return BindingBuilder
+            .bind(orderCompleteQueue())
+            .to(orderExchange())
+            .with(queueOrderComplete);
+    }
 
     @Bean
     public MessageConverter jsonMessageConverter() {

--- a/order-service/src/main/java/com/takeit/order/presentation/controller/OrderMessageListener.java
+++ b/order-service/src/main/java/com/takeit/order/presentation/controller/OrderMessageListener.java
@@ -1,20 +1,51 @@
 package com.takeit.order.presentation.controller;
 
+import java.util.UUID;
+
+import com.takeit.order.application.dto.order.OrderCacheDto;
+import com.takeit.order.application.dto.order.OrderCompleteDto;
 import com.takeit.order.application.service.OrderService;
+import com.takeit.order.application.service.RedisService;
+import com.takeit.order.domain.entity.Order;
+import com.takeit.order.domain.repository.OrderRepository;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OrderMessageListener {
     private final OrderService orderService;
+    private final RedisService redisService;
+    private final OrderRepository orderRepository;
 
     @RabbitListener(queues = "${message.queues.order.cancel}")
     public void receiveMessage(Long orderId) {
         log.info("Received message");
         orderService.cancelOrder(orderId);
+    }
+
+    @Transactional
+    @RabbitListener(queues = "${message.queues.order.complete}")
+    public void handleOrderCompleteMessage(OrderCompleteDto orderCompleteDto) {
+        OrderCacheDto orderCacheDto = redisService.getOrder(orderCompleteDto.orderId().toString());
+        Order order = Order.create(
+            orderCacheDto.uuid(),
+            orderCacheDto.customerId(),
+            orderCacheDto.productId(),
+            orderCacheDto.userCouponId(),
+            orderCacheDto.quantity(),
+            orderCacheDto.amount()
+        );
+
+        orderRepository.save(order);
+
+        redisService.deleteOrder(order.getUuid().toString());
+        redisService.deleteOrderId(order.getUuid().toString());
+        // 재고 차감 db 반영 요청
     }
 }

--- a/order-service/src/main/resources/application-dev.yml
+++ b/order-service/src/main/resources/application-dev.yml
@@ -51,5 +51,6 @@ message:
   queues:
     order:
       cancel: "takeit.order.cancel"
+      complete: "takeit.order.complete"
     product:
       cancel: "takeit.product.cancel"

--- a/order-service/src/main/resources/application-local.yml
+++ b/order-service/src/main/resources/application-local.yml
@@ -51,5 +51,6 @@ message:
   queues:
     order:
       cancel: "takeit.order.cancel"
+      complete: "takeit.order.complete"
     product:
       cancel: "takeit.product.cancel"

--- a/order-service/src/main/resources/application-prod.yml
+++ b/order-service/src/main/resources/application-prod.yml
@@ -52,5 +52,6 @@ message:
   queues:
     order:
       cancel: ${MESSAGE_QUEUE_ORDER_CANCEL}
+      complete: ${MESSAGE_QUEUE_ORDER_COMPLETE}
     product:
       cancel: ${MESSAGE_QUEUE_PRODUCT_CANCEL}

--- a/payment-service/src/main/java/com/takeit/payment/application/dto/order/OrderCompleteDto.java
+++ b/payment-service/src/main/java/com/takeit/payment/application/dto/order/OrderCompleteDto.java
@@ -1,0 +1,12 @@
+package com.takeit.payment.application.dto.order;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+public record OrderCompleteDto(
+	UUID orderId
+) implements Serializable {
+	public static OrderCompleteDto from(UUID orderId) {
+		return new OrderCompleteDto(orderId);
+	}
+}

--- a/payment-service/src/main/java/com/takeit/payment/application/service/PaymentService.java
+++ b/payment-service/src/main/java/com/takeit/payment/application/service/PaymentService.java
@@ -6,6 +6,8 @@ import com.takeit.payment.application.dto.payment.CancelTossPaymentDto;
 import com.takeit.payment.application.dto.payment.VerifyTossPaymentDto;
 import com.takeit.payment.domain.entity.Payment;
 import com.takeit.payment.domain.repository.PaymentRepository;
+import com.takeit.payment.presentation.controller.PaymentMessageProducer;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,8 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final RabbitTemplate rabbitTemplate;
+    private final PaymentMessageProducer paymentMessageProducer;
 
-    @Value("${message.queue.order.cancel}")
+    @Value("${message.queues.order.cancel}")
     private String queueOrder;
 
     @Transactional
@@ -35,6 +38,7 @@ public class PaymentService {
 
         if(isPaymentSuccess) {
             paymentRepository.save(Payment.create(orderId, userId, request.amount(), receipt));
+            paymentMessageProducer.sendOrderCompleteRequest(request.orderId());
         } else {
             rabbitTemplate.convertAndSend(queueOrder, orderId);
 //            throw new CustomException(ErrorCode.WRONG_PAYMENT);

--- a/payment-service/src/main/java/com/takeit/payment/infrastructure/config/RabbitMQConfig.java
+++ b/payment-service/src/main/java/com/takeit/payment/infrastructure/config/RabbitMQConfig.java
@@ -5,6 +5,8 @@ import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,7 +18,7 @@ public class RabbitMQConfig {
     @Value("${message.exchange}")
     private String exchange;
 
-    @Value("${message.queue.order.cancel}")
+    @Value("${message.queues.order.cancel}")
     private String queueOrder;
 
     @Bean
@@ -27,5 +29,10 @@ public class RabbitMQConfig {
 
     @Bean
     public Binding orderBinding() { return BindingBuilder.bind(orderQueue()).to(paymentExchange()).with(queueOrder); }
+
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
 
 }

--- a/payment-service/src/main/java/com/takeit/payment/presentation/controller/PaymentMessageProducer.java
+++ b/payment-service/src/main/java/com/takeit/payment/presentation/controller/PaymentMessageProducer.java
@@ -1,0 +1,31 @@
+package com.takeit.payment.presentation.controller;
+
+import java.util.UUID;
+
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.takeit.payment.application.dto.order.OrderCompleteDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentMessageProducer {
+
+	private final RabbitTemplate rabbitTemplate;
+	private final TopicExchange paymentExchange;
+
+	@Value("${message.queues.order.complete}")
+	private String orderComplete;
+
+	private void sendMessage(String routingKey, Object message) {
+		rabbitTemplate.convertAndSend(paymentExchange.getName(), routingKey, message);
+	}
+
+	public void sendOrderCompleteRequest(UUID orderId){
+		sendMessage(orderComplete, OrderCompleteDto.from(orderId));
+	}
+}

--- a/payment-service/src/main/resources/application-dev.yml
+++ b/payment-service/src/main/resources/application-dev.yml
@@ -13,7 +13,7 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
   rabbitmq:
-    host: localhost
+    host: rabbitMQ
     port: 5672
     username: guest
     password: guest
@@ -45,6 +45,7 @@ management:
 
 message:
   exchange: "takeit"
-  queue:
+  queues:
     order:
       cancel: "takeit.order.cancel"
+      complete: "takeit.order.complete"

--- a/payment-service/src/main/resources/application-local.yml
+++ b/payment-service/src/main/resources/application-local.yml
@@ -12,7 +12,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
   rabbitmq:
-    host: localhost
+    host: rabbitMQ
     port: 5672
     username: guest
     password: guest
@@ -41,8 +41,11 @@ management:
       show-details: always
     prometheus:
       enabled: true
+
 message:
   exchange: "takeit"
-  queue:
+  queues:
     order:
       cancel: "takeit.order.cancel"
+      complete: "takeit.order.complete"
+

--- a/payment-service/src/main/resources/application-prod.yml
+++ b/payment-service/src/main/resources/application-prod.yml
@@ -45,6 +45,7 @@ management:
 
 message:
   exchange: ${RABBITMQ_EXCHANGE}
-  queue:
+  queues:
     order:
       cancel: ${MESSAGE_QUEUE_ORDER_CANCEL}
+      complete: ${MESSAGE_QUEUE_ORDER_COMPLETE}

--- a/product-service/src/main/java/com/takeit/product/presentation/controller/ProductMessageListener.java
+++ b/product-service/src/main/java/com/takeit/product/presentation/controller/ProductMessageListener.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 public class ProductMessageListener {
     private final ProductRedisService productRedisService;
 
-    @RabbitListener(queues = "${message.queue.product.cancel}")
+    @RabbitListener(queues = "${message.queues.product.cancel}")
     public void receiveMessage(String message) {
         log.info("Received message");
 


### PR DESCRIPTION
## **🔗 Related Issues**
> 예) 관련이슈 #번호
#114 

## **📋 Description**
> 이 PR에서 해결한 문제 또는 추가된 기능을 간략히 설명
- 결제 성공 시 주문 정보 저장 기능 구현

## **👀 Review Points**
> 리뷰어가 특별히 봐주었으면 하는 부분

prod에 추가해야 할 환경변수
- ${MESSAGE_QUEUE_ORDER_COMPLETE} : takeit.order.complete
추가해야 합니덩

- 주문 완료 처리 과정에서 재고 차감 db 반영하는 로직 구현 필요합니다