### PR TITLE
feat - product 레디스 데이터를 db에 저장하는 로직추가

### DIFF
--- a/product-service/src/main/java/com/takeit/product/infrastructure/config/RabbitMQConfig.java
+++ b/product-service/src/main/java/com/takeit/product/infrastructure/config/RabbitMQConfig.java
@@ -16,12 +16,38 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @RequiredArgsConstructor
 public class RabbitMQConfig {
+    @Value("${message.exchange}")
+    private String exchange;
 
     @Value("${message.queues.product.cancel}")
-    private String queueProduct;
+    private String queueProductCancel;
+
+    @Value("${message.queues.product.save.db}")
+    private String queueProductSaveDb;
+
+    @Bean public TopicExchange exchange() {
+        return new TopicExchange(exchange);
+    }
 
     @Bean
-    public Queue productQueue() { return new Queue(queueProduct); }
+    public Queue queueProductCancel() {
+        return new Queue(queueProductCancel);
+    }
+
+    @Bean
+    public Queue queueProductSaveDb() {
+        return new Queue(queueProductSaveDb);
+    }
+
+    @Bean
+    public Binding bindingProductCancel() {
+        return BindingBuilder.bind(queueProductCancel()).to(exchange()).with(queueProductCancel);
+    }
+
+    @Bean
+    public Binding bindingProductSaveDb() {
+        return BindingBuilder.bind(queueProductSaveDb()).to(exchange()).with(queueProductSaveDb);
+    }
 
     @Bean
     public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(ConnectionFactory connectionFactory) {

--- a/product-service/src/main/java/com/takeit/product/presentation/controller/ProductMessageListener.java
+++ b/product-service/src/main/java/com/takeit/product/presentation/controller/ProductMessageListener.java
@@ -4,26 +4,42 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.takeit.product.application.dto.product.CancelProduct;
 import com.takeit.product.application.service.ProductRedisService;
+import com.takeit.product.domain.entity.Product;
+import com.takeit.product.domain.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
+
+import java.util.UUID;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ProductMessageListener {
     private final ProductRedisService productRedisService;
+    private final ProductRepository productRepository;
 
     @RabbitListener(queues = "${message.queues.product.cancel}")
-    public void receiveMessage(String message) {
-        log.info("Received message");
+    public void receiveProductCancelMessage(String message) {
+        log.info("Received message: product cancel");
 
         try {
             ObjectMapper objectMapper = new ObjectMapper();
             CancelProduct cancelProduct = objectMapper.readValue(message, CancelProduct.class);
             productRedisService.cancelProduct(cancelProduct);
         } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @RabbitListener(queues = "${message.queues.product.save.db}")
+    public void receiveProductSaveDbMessage(String message) {
+        log.info("Received message: product save db");
+        try {
+            Product product = productRedisService.getProduct(UUID.fromString(message));
+            productRepository.save(product);
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/product-service/src/main/resources/application-dev.yml
+++ b/product-service/src/main/resources/application-dev.yml
@@ -68,6 +68,9 @@ management:
       enabled: true
 
 message:
+  exchange: "takeit"
   queues:
     product:
       cancel: "takeit.product.cancel"
+      save:
+        db: "takeit.product.save.db"

--- a/product-service/src/main/resources/application-local.yml
+++ b/product-service/src/main/resources/application-local.yml
@@ -68,6 +68,9 @@ management:
       enabled: true
 
 message:
+  exchange: "takeit"
   queues:
     product:
-     cancel: "takeit.product.cancel"
+      cancel: "takeit.product.cancel"
+      save:
+        db: "takeit.product.save.db"

--- a/product-service/src/main/resources/application-prod.yml
+++ b/product-service/src/main/resources/application-prod.yml
@@ -63,6 +63,9 @@ management:
       enabled: true
 
 message:
+  exchange: ${RABBITMQ_EXCHANGE}
   queues:
     product:
       cancel: ${MESSAGE_QUEUE_PRODUCT_CANCEL}
+      save:
+        db: ${MESSAGE_QUEUE_PRODUCT_SAVE_DB}


### PR DESCRIPTION
## **🔗 Related Issues**
#114

## **📋 Description**
rabbit mq 세팅
product 레디스 데이터를 db에 저장

## **👀 Review Points**
- prod에 ${MESSAGE_QUEUE_PRODUCT_SAVE_DB} : takeit.product.save.db 추가해야합니다.
- rabbit mq사용이 익숙하지않아 꼼꼼하게 리뷰 부탁드립니다. 틀릴수도 있어요

