### PR TITLE
Feat: 대기열 진입 후 inactive 사용자 처리

### DIFF
--- a/auth-service/src/main/java/com/takeit/auth/infrastructure/client/CouponClient.java
+++ b/auth-service/src/main/java/com/takeit/auth/infrastructure/client/CouponClient.java
@@ -4,9 +4,10 @@ import com.takeit.auth.application.service.CouponService;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "coupon-service")
 public interface CouponClient extends CouponService {
     @PostMapping("/feign/v1/coupons/signup")
-    boolean createSignupUserCoupon(@RequestBody Long userId);
+    boolean createSignupUserCoupon(@RequestParam Long userId);
 }

--- a/coupon-service/src/main/java/com/takeit/coupon/presentation/controller/UserCouponEndPoint.java
+++ b/coupon-service/src/main/java/com/takeit/coupon/presentation/controller/UserCouponEndPoint.java
@@ -31,7 +31,7 @@ public class UserCouponEndPoint {
 
     @PostMapping("/signup")
     public boolean signupUserCoupon(
-            @RequestBody Long userId
+            @RequestParam Long userId
     ) {
         return userCouponService.createSignupUserCoupon(userId);
     }

--- a/order-service/src/main/java/com/takeit/order/application/scheduler/ActiveTokenScheduler.java
+++ b/order-service/src/main/java/com/takeit/order/application/scheduler/ActiveTokenScheduler.java
@@ -22,6 +22,7 @@ public class ActiveTokenScheduler {
     private static final String WAITING_TOKENS = "waitingTokens";
     private static final String ACTIVE_TOKENS = "activeTokens";
     private static final String ACTIVE_USERS = "activeUsers";
+    private static final String WAITING_USERS = "waitingUsers";
     @Value("${queue.max-active-size}")
     private int MAX_ACTIVE_SIZE; // 최대 active token 수
     private static final long ACTIVE_TTL_SECONDS = 5; // active token TTL (5초)
@@ -37,7 +38,7 @@ public class ActiveTokenScheduler {
 //        log.info("Scheduler end");
 //    }
 
-    @Scheduled(fixedRate = 2000)
+//    @Scheduled(fixedRate = 2000)
     public void manageActiveTokensInOneQueue() {
         Set<String> keys = getAllActiveTokens();
         int activeUserSize = keys == null ? 0 : keys.size();
@@ -62,6 +63,7 @@ public class ActiveTokenScheduler {
             log.info("create active token : {}", activeKey);
             redisTemplate.opsForZSet().remove(WAITING_TOKENS, key);
             log.info("remove waiting token : {}", key);
+            redisTemplate.delete(WAITING_USERS + ":username:" + key);
         }
 
         log.info("finish key move");

--- a/order-service/src/main/java/com/takeit/order/application/scheduler/ActiveTokenScheduler.java
+++ b/order-service/src/main/java/com/takeit/order/application/scheduler/ActiveTokenScheduler.java
@@ -38,7 +38,7 @@ public class ActiveTokenScheduler {
 //        log.info("Scheduler end");
 //    }
 
-//    @Scheduled(fixedRate = 2000)
+    @Scheduled(fixedRate = 2000)
     public void manageActiveTokensInOneQueue() {
         Set<String> keys = getAllActiveTokens();
         int activeUserSize = keys == null ? 0 : keys.size();

--- a/order-service/src/main/java/com/takeit/order/application/service/QueueService.java
+++ b/order-service/src/main/java/com/takeit/order/application/service/QueueService.java
@@ -29,12 +29,15 @@ public class QueueService {
     private static final String WAITING_TOKENS = "waitingTokens";
     private static final String ACTIVE_TOKENS = "activeTokens";
     private static final String ACTIVE_USERS = "activeUsers";
+    private static final String WAITING_USERS = "waitingUsers";
+    private static final long WAITING_TTL_SECONDS = 60; // waiting TTL (60초)
     private static final int MAX_ACTIVE_SIZE = 100; // 최대 active token 수
     private static final long ACTIVE_TTL_SECONDS = 5; // active token TTL (5초)
 
     public boolean joinOneQueue(String username) {
         long currentTime = System.currentTimeMillis();
         stringRedisTemplate.opsForZSet().add(WAITING_TOKENS, username, currentTime);
+        setWaitingUserTtl(username);
         log.info("username : {}", username);
 
         return false;
@@ -109,6 +112,7 @@ public class QueueService {
         Long rank = stringRedisTemplate.opsForZSet().rank(WAITING_TOKENS, username);
 
         if(rank != null) {
+            setWaitingUserTtl(username);
             return QueueDto.of(rank, false);
         }
 
@@ -120,5 +124,10 @@ public class QueueService {
 
         throw new CustomException(QUEUE_NOT_FOUND);
 
+    }
+
+    private void setWaitingUserTtl(String username) {
+        String key = WAITING_USERS + ":username:" + username;
+        stringRedisTemplate.opsForValue().set(key, "active", WAITING_TTL_SECONDS, TimeUnit.SECONDS);
     }
 }

--- a/order-service/src/main/java/com/takeit/order/application/service/RedisService.java
+++ b/order-service/src/main/java/com/takeit/order/application/service/RedisService.java
@@ -20,6 +20,8 @@ public class RedisService {
 	private final RedisTemplate<String, Object> redisTemplate;
 	private final RedisTemplate<String, String> stringRedisTemplate;
 	private static final String ACTIVE_USERS = "activeUsers";
+	private static final String WAITING_TOKENS = "waitingTokens";
+	private static final String WAITING_USERS = "waitingUsers";
 
 
 	public void saveOrderId(UUID orderId, long ttl){
@@ -57,4 +59,11 @@ public class RedisService {
 		Long remove = stringRedisTemplate.opsForSet().remove(activeSetKey, username);
 	}
 
+	public void deleteWaitingToken(String username) {
+		stringRedisTemplate.opsForZSet().remove(WAITING_TOKENS, username);
+	}
+
+	public void deleteWaitingUserTtl(String username) {
+		stringRedisTemplate.delete(WAITING_USERS + ":username:" + username);
+	}
 }

--- a/order-service/src/main/java/com/takeit/order/infrastructure/redis/RedisKeyExpirationListener.java
+++ b/order-service/src/main/java/com/takeit/order/infrastructure/redis/RedisKeyExpirationListener.java
@@ -25,6 +25,7 @@ public class RedisKeyExpirationListener implements MessageListener {
 
 		if(expiredKey.startsWith("orderId:")) handleOrderExpiration(expiredKey.substring(8));
 //		if(expiredKey.startsWith("activeTokens:")) handleActiveUserExpiration(expiredKey);
+		if(expiredKey.startsWith("waitingUsers:")) handleWaitingUserExpiration(expiredKey.substring(22));
 	}
 
 	private void handleOrderExpiration(String key){
@@ -37,5 +38,10 @@ public class RedisKeyExpirationListener implements MessageListener {
 		String productId = parts[2];
 		String username = parts[4];
 		redisService.deleteActiveUser(productId, username);
+	}
+
+	private void handleWaitingUserExpiration(String key){
+		log.info("key : {}", key);
+		redisService.deleteWaitingToken(key);
 	}
 }

--- a/review-service/src/main/java/com/takeit/review/application/service/ReviewService.java
+++ b/review-service/src/main/java/com/takeit/review/application/service/ReviewService.java
@@ -54,7 +54,7 @@ public class ReviewService {
 
         if(orderDto == null)
             throw new CustomException(ORDER_NOT_FOUND);
-        if(!orderDto.status().equals("DELIVERED"))
+        if(!orderDto.status().equals("COMPLETED"))
             throw new CustomException(ORDER_NOT_DELIVERED);
 
         if(reviewRepository.existsByOrderIdAndIsDeletedIsFalse(orderDto.orderId())) {


### PR DESCRIPTION
## **🔗 Related Issues**
> #128 


## **📋 Description**
대기열 진입 후 inactive 사용자 처리
- 대기열 진입 시 String key와 ttl 60초로 waitingUsers 를 생성 후 getOneQueueInRankAndIsActive 메서드를 호출 시 ttl을 새로 갱신합니다. ttl 만료시 waitingTokens에서 해당 유저를 삭제합니다.


## **👀 Review Points**
> 리뷰어가 특별히 봐주었으면 하는 부분
